### PR TITLE
Avoid page blink when clicking a "surprise me" link

### DIFF
--- a/layouts/partials/surprise-me-head.html
+++ b/layouts/partials/surprise-me-head.html
@@ -1,13 +1,3 @@
 {{ if eq .Type "surpriseme" }}
   <meta name="robots" content="noindex" />
-
-  <style>
-    html.preparing-surprise {
-      visibility: hidden;
-    }
-  </style>
-
-  <script>
-    document.documentElement.classList.add('preparing-surprise');
-  </script>
 {{ end }}

--- a/layouts/surpriseme/single.html
+++ b/layouts/surpriseme/single.html
@@ -13,11 +13,13 @@
 
   {{ .Content }}
 
-  {{ $.Scratch.Set "index" 0 }}
-  {{ range (shuffle $posts) }}
-    {{ $.Scratch.Set "index" (add ($.Scratch.Get "index") 1) }}
-    <a href="{{ .Permalink }}" class="surprise-me-link">{{ $.Scratch.Get "index" }}</a>
-  {{ end }}
+  <div style="display:none;">
+    {{ $.Scratch.Set "index" 0 }}
+    {{ range (shuffle $posts) }}
+      {{ $.Scratch.Set "index" (add ($.Scratch.Get "index") 1) }}
+      <a href="{{ .Permalink }}" class="surprise-me-link">{{ $.Scratch.Get "index" }}</a>
+    {{ end }}
+  </div>
 
   <script>
     const sample = (array) => array[Math.floor(Math.random() * array.length)];

--- a/layouts/surpriseme/single.html
+++ b/layouts/surpriseme/single.html
@@ -13,7 +13,22 @@
 
   {{ .Content }}
 
-  <div style="display:none;">
+  <style>
+    .surprise-me {
+    	animation: surpriseFadeIn 0.3s;
+    	animation-delay: 2s;
+    	animation-fill-mode: forwards;
+    
+    	opacity: 0;
+    }
+    
+    @keyframes surpriseFadeIn {
+      0% { opacity: 0; }
+      100% { opacity: 1; }
+    }
+  </style>
+
+  <div class="surprise-me">
     {{ $.Scratch.Set "index" 0 }}
     {{ range (shuffle $posts) }}
       {{ $.Scratch.Set "index" (add ($.Scratch.Get "index") 1) }}


### PR DESCRIPTION
## What does this PR do?

It moves the hiding of the surprise from a global class on the html element to a wrapping div around the links.

## Why was this PR needed?

In the current version of the plugin, all content on the webpage is hidden during the surprise preparation. Including whatever header or menu that usually remains stable at the top of the page. This results in the content blinking in a somewhat jarring way. Even though it really is in an itsy-bitsy-tiny papercut kind of way.

### Without this PR:

https://github.com/svendahlstrand/plugin-surprise-me/assets/52966/67da513f-11a2-4808-a781-c31e34a16f5d

### With this PR:

https://github.com/svendahlstrand/plugin-surprise-me/assets/52966/63ee1077-afda-4fa3-bb4a-f148c8d975da